### PR TITLE
chore: fix Dockerfile building error

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache --virtual .build-tools git g++ build-base linux-headers c
     install -d /usr/include/date/ && \
     install -m644 libcron/externals/date/include/date/* /usr/include/date/ && \
     cd .. && \
-    git clone https://github.com/ToruNiina/toml11 --depth=1 && \
+    git clone https://github.com/ToruNiina/toml11 --branch v3.7.1 --depth=1 && \
     cd toml11 && \
     cmake -DCMAKE_CXX_STANDARD=11 . && \
     make install -j $THREADS && \


### PR DESCRIPTION
https://github.com/MetaCubeX/subconverter/actions/runs/6491424492/job/17628728260
![image](https://github.com/MetaCubeX/subconverter/assets/21117946/e817a110-be15-472c-9a93-ec9c724d35d5)

看日志是 https://github.com/ToruNiina/toml11 这个上游依赖的问题，回退下版本就能过编译了。
猜测应该是上游3天前这个新commit有bug，我不懂C不太敢往上游提issue（
https://github.com/ToruNiina/toml11/commit/c32a20e1ee690d6e6bf6f37e6d603402d49b15f0
