### PR TITLE
Fix `scv` parameter not working with `hysteria2` and `trojan`

### DIFF
--- a/scripts/build.macos.release.sh
+++ b/scripts/build.macos.release.sh
@@ -14,41 +14,41 @@ brew reinstall rapidjson libevent zlib pcre2 pkgconfig
 git clone https://github.com/jbeder/yaml-cpp --depth=1
 cd yaml-cpp
 cmake -DCMAKE_BUILD_TYPE=Release -DYAML_CPP_BUILD_TESTS=OFF -DYAML_CPP_BUILD_TOOLS=OFF . > /dev/null
-make install -j8 > /dev/null
+sudo make install -j8 > /dev/null
 cd ..
 
 git clone https://github.com/ftk/quickjspp --depth=1
 cd quickjspp
 cmake -DCMAKE_BUILD_TYPE=Release .
-make quickjs -j8
-install -d /usr/local/lib/quickjs/
-install -m644 quickjs/libquickjs.a /usr/local/lib/quickjs/
-install -d /usr/local/include/quickjs/
-install -m644 quickjs/quickjs.h quickjs/quickjs-libc.h /usr/local/include/quickjs/
-install -m644 quickjspp.hpp /usr/local/include/
+sudo make quickjs -j8
+sudo install -d /usr/local/lib/quickjs/
+sudo install -m644 quickjs/libquickjs.a /usr/local/lib/quickjs/
+sudo install -d /usr/local/include/quickjs/
+sudo install -m644 quickjs/quickjs.h quickjs/quickjs-libc.h /usr/local/include/quickjs/
+sudo install -m644 quickjspp.hpp /usr/local/include/
 cd ..
 
 git clone https://github.com/PerMalmberg/libcron --depth=1
 cd libcron
 git submodule update --init
 cmake -DCMAKE_BUILD_TYPE=Release .
-make libcron install -j8
-install -m644 libcron/out/Release/liblibcron.a /usr/local/lib/
-install -d /usr/local/include/libcron/
-install -m644 libcron/include/libcron/* /usr/local/include/libcron/
-install -d /usr/local/include/date/
-install -m644 libcron/externals/date/include/date/* /usr/local/include/date/
+sudo make libcron install -j8
+sudo install -m644 libcron/out/Release/liblibcron.a /usr/local/lib/
+sudo install -d /usr/local/include/libcron/
+sudo install -m644 libcron/include/libcron/* /usr/local/include/libcron/
+sudo install -d /usr/local/include/date/
+sudo install -m644 libcron/externals/date/include/date/* /usr/local/include/date/
 cd ..
 
 git clone https://github.com/ToruNiina/toml11 --depth=1
 cd toml11
 cmake -DCMAKE_CXX_STANDARD=11 .
-make install -j4
+sudo make install -j4
 cd ..
 
-cp /usr/local/lib/libevent.a .
-cp /usr/local/opt/zlib/lib/libz.a .
-cp /usr/local/lib/libpcre2-8.a .
+cp /opt/homebrew/lib/libevent.a .
+cp /opt/homebrew/opt/zlib/lib/libz.a .
+cp /opt/homebrew/lib/libpcre2-8.a .
 
 cmake -DCMAKE_BUILD_TYPE=Release .
 make -j8

--- a/scripts/build.windows.release.sh
+++ b/scripts/build.windows.release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xe
 
-git clone https://github.com/curl/curl --depth=1 --branch curl-7_88_1
+git clone https://github.com/curl/curl --depth=1
 cd curl
 cmake -DCMAKE_BUILD_TYPE=Release -DCURL_USE_LIBSSH2=OFF -DHTTP_ONLY=ON -DCURL_USE_SCHANNEL=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_CURL_EXE=OFF -DCMAKE_INSTALL_PREFIX="$MINGW_PREFIX" -G "Unix Makefiles" -DHAVE_LIBIDN2=OFF -DCURL_USE_LIBPSL=OFF .
 make install -j4

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -363,8 +363,6 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
                     singleproxy["sni"] = x.Host;
                 if (!scv.is_undef())
                     singleproxy["skip-cert-verify"] = scv.get();
-                if (!x.AllowInsecure.is_undef())
-                    singleproxy["skip-cert-verify"] = x.AllowInsecure.get();
                 if (!x.Alpn.empty())
                     singleproxy["alpn"].push_back(x.Alpn);
                 if (!x.OBFSParam.empty())
@@ -497,8 +495,6 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
                 singleproxy["password"].SetTag("str");
             if(!scv.is_undef())
                 singleproxy["skip-cert-verify"] = scv.get();
-            if (!x.AllowInsecure.is_undef())
-                singleproxy["skip-cert-verify"] = x.AllowInsecure.get();
             switch(hash_(x.TransferProtocol))
             {
             case "tcp"_hash:

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1353,7 +1353,6 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             singleproxy["sni"] >>= host;
             singleproxy["alpn"][0] >>= alpn;
 
-            scv = singleproxy["insecure"].IsDefined() ? singleproxy["insecure"].as<std::string>() == "1" : false;
             hysteria2Construct(node, group, ps, server, port, password, host, up, down, alpn, obfsParam, obfsPassword, udp, tfo, scv);
             break;
         default:


### PR DESCRIPTION
This pull request fixes the issue where the `scv` parameter was ineffective when passed into `hysteria2` and `trojan`.