### PR TITLE
ci: update macOS runner versions for better stability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,10 @@ jobs:
         include:
           - arch: x86
             artifact: subconverter_darwin64
-            os: macos-13
+            os: macos-15-intel
           - arch: arm
             artifact: subconverter_darwinarm
-            os: macos-14
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     name: macOS ${{ matrix.arch }} Build
     steps:


### PR DESCRIPTION
- Update macOS x86 runner from macos-13 to macos-15-intel
- Update macOS ARM runner from macos-14 to macos-latest
- Ensures compatibility with latest GitHub Actions runner infrastructure