### PR TITLE
Add support for unencoded subscriptions

### DIFF
--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -3222,7 +3222,10 @@ void explodeSub(std::string sub, std::vector<Proxy> &nodes)
     //try to parse as normal subscription
     if(!processed)
     {
-        sub = urlSafeBase64Decode(sub);
+        if(isBase64(sub))
+        {
+            sub = urlSafeBase64Decode(sub);
+        }
         if(regFind(sub, "(vmess|shadowsocks|http|trojan)\\s*?="))
         {
             if(explodeSurge(sub, nodes))

--- a/src/utils/base64/base64.cpp
+++ b/src/utils/base64/base64.cpp
@@ -147,3 +147,24 @@ std::string urlSafeBase64Encode(const std::string &string_to_encode)
 {
     return urlSafeBase64Apply(base64Encode(string_to_encode));
 }
+bool isBase64(const std::string &string_to_check)
+{
+    if (string_to_check.empty())
+        return false;
+
+    string_size len = string_to_check.size();
+    if (len % 4 != 0)
+        return false;
+
+    for (string_size i = 0; i < len; i++)
+    {
+        unsigned char c = string_to_check[i];
+        if (base64_chars.find(c) == std::string::npos && c != '=')
+            return false;
+
+        if (c == '=' && i < len - 2)
+            return false;
+    }
+
+    return true;
+}

--- a/src/utils/base64/base64.h
+++ b/src/utils/base64/base64.h
@@ -11,4 +11,6 @@ std::string urlSafeBase64Reverse(const std::string &encoded_string);
 std::string urlSafeBase64Decode(const std::string &encoded_string);
 std::string urlSafeBase64Encode(const std::string &string_to_encode);
 
+bool isBase64(const std::string &string_to_check);
+
 #endif // BASE64_H_INCLUDED


### PR DESCRIPTION
This small PR adds the ability to handle unencoded (plain text) subscription URLs in subconverter, improving flexibility for users.

**Changes Made**

- Updated subscription parsing to support both base64-encoded and plain text formats.

**Testing**

- Verified with sample unencoded URLs; existing base64 subscriptions still work.

No breaking changes. Ready for merge!