### PR TITLE
feat(Loon): add VLESS node export support

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -2310,6 +2310,43 @@ std::string proxyToLoon(std::vector<Proxy> &nodes, const std::string &base_conf,
             if(!x.SNI.empty())
                 proxy += ",sni=" + x.SNI;
             break;
+        case ProxyType::VLESS:
+        {
+            std::string vless_uuid = x.UUID.empty() ? x.UserId : x.UUID;
+            std::string vless_transport = transproto.empty() ? "tcp" : transproto;
+
+            proxy = "VLESS," + hostname + "," + port + ",\"" + vless_uuid + "\"";
+
+            if(vless_transport == "tcp" || vless_transport == "ws" || vless_transport == "http")
+                proxy += ",transport=" + vless_transport;
+            else
+                continue;
+
+            if(vless_transport == "ws" || vless_transport == "http")
+            {
+                if(!path.empty())
+                    proxy += ",path=" + path;
+                if(!host.empty())
+                    proxy += ",host=" + host;
+            }
+
+            proxy += ",over-tls=" + std::string(tlssecure ? "true" : "false");
+            if(!x.SNI.empty())
+                proxy += ",sni=" + x.SNI;
+            if(!scv.is_undef())
+                proxy += ",skip-cert-verify=" + std::string(scv.get() ? "true" : "false");
+
+            if(x.XTLS == 2)
+                proxy += ",flow=xtls-rprx-vision";
+            else if(!x.Flow.empty())
+                proxy += ",flow=" + x.Flow;
+
+            if(!x.PublicKey.empty())
+                proxy += ",public-key=\"" + x.PublicKey + "\"";
+            if(!x.ShortID.empty())
+                proxy += ",short-id=" + x.ShortID;
+            break;
+        }
         default:
             continue;
         }


### PR DESCRIPTION
## Summary
- 为 `loon` 目标新增 `VLESS` 节点导出能力，补齐 `proxyToLoon` 中缺失的协议分支。
- 按 Loon 节点格式输出 `transport=tcp/ws/http`、`path`、`host`、`over-tls`、`sni`、`skip-cert-verify`、`flow`、`public-key`、`short-id` 等参数。
- 兼容两种 UUID 字段来源（优先 `UUID`，回退 `UserId`），避免不同来源订阅在导出时丢失身份字段。

## Reference
- Loon Node 文档: https://nsloon.app/docs/Node/

## Verification
- 已在本地构建镜像并验证服务可正常运行。
- 实测导出后的 Loon VLESS 节点可正常使用。