### PR TITLE
Allow Reality export when shortId is empty

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,17 +4,28 @@ on:
     branches: [ master ]
     tags:
       - '**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch/tag/sha to build
+        required: false
+        default: master
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 env:
-  REGISTRY_IMAGE: metacubex/subconverter
-  GHCR_IMAGE: ghcr.io/metacubex/subconverter
+  REGISTRY_IMAGE: ${{ github.repository_owner }}/subconverter
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/subconverter
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build-dockerhub:
+    if: ${{ secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}
     strategy:
       matrix:
         include:
@@ -38,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -57,7 +69,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Get commit SHA
-        if: github.ref == 'refs/heads/master'
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
@@ -110,6 +121,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -130,7 +142,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get commit SHA
-        if: github.ref == 'refs/heads/master'
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
@@ -162,6 +173,7 @@ jobs:
   merge-dockerhub:
     name: Merge Docker Hub
     needs: build-dockerhub
+    if: ${{ secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download digests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,14 +18,30 @@ concurrency:
 env:
   REGISTRY_IMAGE: ${{ github.repository_owner }}/subconverter
   GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/subconverter
+  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 permissions:
   contents: read
   packages: write
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      dockerhub_enabled: ${{ steps.check.outputs.dockerhub_enabled }}
+    steps:
+      - id: check
+        run: |
+          if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
+            echo "dockerhub_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dockerhub_enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-dockerhub:
-    if: ${{ secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}
+    needs: precheck
+    if: ${{ needs.precheck.outputs.dockerhub_enabled == 'true' }}
     strategy:
       matrix:
         include:
@@ -49,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -65,8 +81,8 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Get commit SHA
         id: vars
@@ -121,7 +137,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -172,8 +188,8 @@ jobs:
 
   merge-dockerhub:
     name: Merge Docker Hub
-    needs: build-dockerhub
-    if: ${{ secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}
+    needs: [precheck, build-dockerhub]
+    if: ${{ needs.precheck.outputs.dockerhub_enabled == 'true' && needs.build-dockerhub.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download digests
@@ -197,8 +213,8 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests-dockerhub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,7 +93,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           platforms: ${{ matrix.platform }}
-          context: scripts/
+          context: .
+          file: scripts/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SHA=${{ steps.vars.outputs.sha_short }}
@@ -166,7 +167,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           platforms: ${{ matrix.platform }}
-          context: scripts/
+          context: .
+          file: scripts/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SHA=${{ steps.vars.outputs.sha_short }}

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -33,11 +33,14 @@ RUN set -xe && \
     git clone https://github.com/ToruNiina/toml11 --branch="v4.3.0" --depth=1 && \
     cd toml11 && \
     cmake -DCMAKE_CXX_STANDARD=11 . && \
-    make install -j $THREADS && \
-    cd .. && \
-    git clone https://github.com/metacubex/subconverter --depth=1 && \
-    cd subconverter && \
-    [ -n "$SHA" ] && sed -i 's/\(v[0-9]\.[0-9]\.[0-9]\)/\1-'"$SHA"'/' src/version.h;\
+    make install -j $THREADS
+
+# Build subconverter from the current build context (the repository checkout),
+# not from a hard-coded upstream git clone.
+COPY . /subconverter
+WORKDIR /subconverter
+RUN set -xe && \
+    [ -n "$SHA" ] && sed -i 's/\(v[0-9]\.[0-9]\.[0-9]\)/\1-'"$SHA"'/' src/version.h; \
     python3 -m ensurepip && \
     python3 -m pip install gitpython && \
     python3 scripts/update_rules.py -c scripts/rules_config.conf && \

--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -697,9 +697,10 @@ void proxyToClash(std::vector<Proxy> &nodes, YAML::Node &yamlnode, const ProxyGr
                 // Fallback for backward compatibility
                 singleproxy["flow"] = x.Flow;
             }
-            if (!x.PublicKey.empty() && !x.ShortID.empty()) {
+            if (!x.PublicKey.empty()) {
                 singleproxy["reality-opts"]["public-key"] = x.PublicKey;
-                singleproxy["reality-opts"]["short-id"] = x.ShortID;
+                if (!x.ShortID.empty())
+                    singleproxy["reality-opts"]["short-id"] = x.ShortID;
                 if (!x.ClientFingerprint.empty()) {
                     singleproxy["client-fingerprint"] = x.ClientFingerprint;
                 } else if (!x.Fingerprint.empty()) {
@@ -2804,7 +2805,7 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
                     tls.AddMember("alpn", alpn, allocator);
                 }
 
-                if (!x.PublicKey.empty() && !x.ShortID.empty()) {
+                if (!x.PublicKey.empty()) {
                     rapidjson::Value reality(rapidjson::kObjectType);
                     reality.AddMember("enabled", true, allocator);
                     if (!x.PublicKey.empty())


### PR DESCRIPTION
Update Reality export conditions for Clash and Sing-Box so that presence of a public key is sufficient, and shortId becomes optional. This matches the XTLS transport spec allowing empty client shortId when server shortIds contain an empty value.