### PR TITLE
Accept plaintext SS userinfo emitted by Sub-Store

### DIFF
--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -609,6 +609,9 @@ void explodeVmessConf(std::string content, std::vector<Proxy> &nodes)
 void explodeSS(std::string ss, Proxy &node)
 {
     std::string ps, password, method, server, port, plugins, plugin, pluginopts, addition, group = SS_DEFAULT_GROUP, secret;
+    auto parse_ss_userinfo = [&](const std::string &userinfo) {
+        return regGetMatch(userinfo, "(\\S+?):(\\S+)", 3, 0, &method, &password) == 0;
+    };
     //std::vector<std::string> args, secret;
     ss = replaceAllDistinct(ss.substr(5), "/?", "?");
     if(strFind(ss, "#"))
@@ -634,7 +637,7 @@ void explodeSS(std::string ss, Proxy &node)
     {
         if(regGetMatch(ss, "(\\S+?)@(\\S+):(\\d+)", 4, 0, &secret, &server, &port))
             return;
-        if(regGetMatch(urlSafeBase64Decode(secret), "(\\S+?):(\\S+)", 3, 0, &method, &password))
+        if(!parse_ss_userinfo(urlSafeBase64Decode(secret)) && !parse_ss_userinfo(urlDecode(secret)))
             return;
     }
     else


### PR DESCRIPTION
## Problem

`explodeSS()` currently assumes that the userinfo before `@` is always
URL-safe base64 when parsing links in the `ss://...@server:port` form.

Accepted today:

```text
ss://<base64(method:password)>@server:port#remark
```

Example shape:

```text
ss://YWVzLTI1Ni1nY206YzJWamNtVjA@server.example.com:443#Node
```

But Sub-Store can also emit a different shape where the userinfo is
plaintext and URL-encoded instead of base64-encoded:

```text
ss://<method>:<urlencoded password>@server:port#remark
```

Example shape:

```text
ss://aes-256-gcm:c2VjcmV0JTNEJTNE@server.example.com:443#Node
```

Because the parser only tries `urlSafeBase64Decode(secret)` in this code
path, links in the plaintext-userinfo shape are rejected.

## Change

Keep the existing base64 parsing path and add a fallback that parses
URL-decoded plaintext `method:password` from the SS userinfo.

This preserves current behavior for existing inputs while accepting the
Sub-Store output shape above.

## Verification

- Existing base64-userinfo SS links still work
- Sub-Store-generated plaintext-userinfo SS links now work
- Existing non-SS conversion behavior is unchanged
