### PR TITLE
fix(clash): quote reality short-id values

### DIFF
--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <mutex>
 #include <numeric>
+#include <regex>
 
 #include <yaml-cpp/yaml.h>
 
@@ -41,6 +42,12 @@ std::string parseProxy(const std::string &source)
     else if(source == "NONE")
         proxy = "";
     return proxy;
+}
+
+std::string quoteRealityShortID(const std::string &content)
+{
+    static const std::regex short_id_pattern(R"(short-id:\s*(?!["'])([^,}\]\s#]+))");
+    return std::regex_replace(content, short_id_pattern, R"(short-id: "$1")");
 }
 
 extern string_array ClashRuleTypes, SurgeRuleTypes, QuanXRuleTypes;
@@ -780,6 +787,8 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
             }
             output_content = proxyToClash(nodes, base_content, lRulesetContent, lCustomProxyGroups, argTarget == "clashr", ext);
         }
+
+        output_content = quoteRealityShortID(output_content);
 
         if(argUpload)
             uploadGist(argTarget, argUploadPath, output_content, false);


### PR DESCRIPTION
## Summary
- Quote unquoted `short-id` values in Clash/ClashR output before returning or uploading via Gist
- Prevent numeric-looking Reality short IDs from being parsed as YAML integers by Mihomo/ClashMeta consumers

## Test plan
- Built fork successfully via GitHub Actions run: https://github.com/argoclaw/subconverter/actions/runs/26141268818
- Verified Linux artifacts were produced for x86/x86_64
- Confirmed PR diff only touches `src/handler/interfaces.cpp` and `src/version.h`; no workflow changes included
