### PR TITLE
feat(Surge): add AnyTLS protocol support for Surge export

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -1118,6 +1118,15 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
             if(!x.SNI.empty())
                 proxy += ",sni=" + x.SNI;
             break;
+        case ProxyType::AnyTLS:
+            if(surge_ver < 4)
+                continue;
+            proxy = "anytls, " + hostname + ", " + port + ", password=" + password;
+            if(!x.SNI.empty())
+                proxy += ", sni=" + x.SNI;
+            if(!scv.is_undef())
+                proxy += ", skip-cert-verify=" + std::string(scv.get() ? "true" : "false");
+            break;
         default:
             continue;
         }


### PR DESCRIPTION
## What

Add AnyTLS protocol support to the Surge target in `proxyToSurge`.

## Why

Surge added AnyTLS support (iOS 5.17.0+, Mac 6.4.3+, syntax `Name = anytls, server, port, password=...`). However `proxyToSurge` had no `AnyTLS` case, so AnyTLS nodes fell into `default: continue;` and were silently dropped. Converting an AnyTLS-only subscription to `target=surge` therefore produced empty output, while `target=clash` (which already supports AnyTLS) worked.

## How

Emit a proper Surge AnyTLS line with `password`, optional `sni` and `skip-cert-verify`, gated on `surge_ver >= 4` consistent with the existing TUIC / Hysteria2 cases. The common post-switch handling already appends `udp-relay`/`tfo` when defined.

```
🇭🇰 Hong Kong 01 = anytls, example.com, 4048, password=xxx, sni=xxx, skip-cert-verify=true, udp-relay=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)